### PR TITLE
Please improve how you specify the license

### DIFF
--- a/edit-at-point.el
+++ b/edit-at-point.el
@@ -1,6 +1,7 @@
 ;;; edit-at-point.el --- edit(copy,cut..) current things(word,symbol..) under cursor
 
 ;; Author: <e.enoson@gmail.com>
+;; License: MIT
 ;; URL: http://github.com/enoson/edit-at-point.el
 ;; Version: 1.1
 


### PR DESCRIPTION
I am the maintainer of the [Emacsmirror](https://emacsmirror.org), which mirrors more than seven thousand Emacs packages.  Each package [is distributed](https://github.com/emacsmirror) as a Git repository.

Because I distribute these packages, I have to worry about how they are licensed.  Packages should be compatible with the license used by Emacs, i.e. version 3 of the GPL.  To ensure that this is the case I obviously have to detect the license.

I have written a library to do so called [`elx`](https://github.com/emacscollective/elx).  It can extract the license from the permission statement at the beginning of a "main" library, the `License` header at the beginning of the library, or the `LICENSE` file in the same repository.

In theory that should get the job done, but with more than 7000 packages we have to expect some issues.  Over the years `elx` therefore has been taught about variations of the default permission statements that are used in the wild and even many non-standard permission statements that, while possibly weird, still unambiguously identify the license.

Finally a handful of packages (15 out of 7328) specify the license in a way where even that is not enough. For these packages it was necessary to hardcode the license inside of `elx`.  

Unfortunately three of your package are among them.

This pull-request changes how the license is specified, it does *not* change the license.